### PR TITLE
Add wheel precision property to prevent model bouncing in display

### DIFF
--- a/pybabylonjs/babylonjs.py
+++ b/pybabylonjs/babylonjs.py
@@ -32,6 +32,7 @@ class BabylonJS(DOMWidget):
     token = Unicode(os.getenv("TILEDB_REST_TOKEN", "")).tag(sync=True)
     uri = Unicode().tag(sync=True)
     value = Dict().tag(sync=True)
+    wheel_precision = Float(50.0).tag(sync=True)
     z_scale = Float(0.5).tag(sync=True)
 
     @validate("value")

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -31,6 +31,7 @@ export class BabylonJSModel extends DOMWidgetModel {
       uri: '',
       width: 700,
       height: 500,
+      wheel_precision: 50.0,
       z_scale: 0.5
     };
   }
@@ -80,6 +81,7 @@ export class BabylonJSView extends DOMWidgetView {
     const data = JSON.parse(this.model.get('value'));    
     const extents = this.model.get('extents');
     const z_scale = this.model.get('z_scale');
+    const wheel_precision = this.model.get('wheel_precision');
     const num_coords = data.X.length
     const minx = extents[0];
     const maxx = extents[1];
@@ -87,6 +89,8 @@ export class BabylonJSView extends DOMWidgetView {
     const maxy = extents[3];
     const minz = extents[4];
     const maxz = extents[5];
+
+    camera.wheelPrecision = wheel_precision
 
     const pcs = new BABYLON.PointsCloudSystem("pcs", 1, scene, { updatable: false });
   


### PR DESCRIPTION
Added property for setting wheel precision within the Babylon widget, this makes a noticeable performance improvement when zooming large point clouds.