### PR TITLE
Update Ubuntu CI to 20.04

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -19,10 +19,10 @@ stages:
           imageName: 'macOS-10.15'
           python.version: '3.7'
         linux_py36:
-          imageName: 'ubuntu-16.04'
+          imageName: 'ubuntu-20.04'
           python.version: '3.6'
         linux_py37:
-          imageName: 'ubuntu-16.04'
+          imageName: 'ubuntu-20.04'
           python.version: '3.7'
     pool:
       vmImage: $(imageName)


### PR DESCRIPTION
Ubuntu 16.04 has been removed from Azure so we need to run 20.04 now.