### PR TITLE
Always load a token from the environment when on TileDB Cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4",
     "@jupyterlab/application": "^3.4.5",
-    "@tiledb-inc/viz-core": "1.0.1"
+    "@tiledb-inc/viz-core": "^1.0.2-alpha.1"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4",
     "@jupyterlab/application": "^3.4.5",
-    "@tiledb-inc/viz-core": "^1.0.2-alpha.1"
+    "@tiledb-inc/viz-core": "^1.0.2-alpha.2"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4",
     "@jupyterlab/application": "^3.4.5",
-    "@tiledb-inc/viz-core": "1.0.0"
+    "@tiledb-inc/viz-core": "1.0.1"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.1.0",

--- a/pybabylonjs/args.py
+++ b/pybabylonjs/args.py
@@ -47,7 +47,7 @@ POINT_CLOUD_ARGS_DEFAULTS = {
 }
 
 
-def check_point_cloud_args(mode, point_cloud_args_in):
+def check_point_cloud_args(source, mode, point_cloud_args_in):
     if mode == "time":
         raise ValueError("This mode will be implemented soon")
     if mode == "classes":
@@ -76,6 +76,16 @@ def check_point_cloud_args(mode, point_cloud_args_in):
     if not "height" in point_cloud_args:
         point_cloud_args["height"] = 600
         point_cloud_args["width"] = 800
+
+    if not "token" in point_cloud_args:
+        try:
+            token = os.getenv("TILEDB_REST_TOKEN")
+        except:
+            if source == "cloud" & token == None:
+                raise ValueError(
+                    "The TileDB Cloud token needed to access the array is not specified or cannot be accessed"
+                )
+        point_cloud_args = {**point_cloud_args, "token": token}
 
     return point_cloud_args
 
@@ -121,14 +131,6 @@ def check_point_cloud_data_local(mode, uri, point_cloud_args):
 
 
 def check_point_cloud_data_cloud(streaming, uri, point_cloud_args):
-    if not "token" in point_cloud_args:
-        token = os.getenv("TILEDB_REST_TOKEN")
-        if token == None:
-            raise ValueError(
-                "The TileDB Cloud token needed to access the array is not specified or cannot be accessed"
-            )
-        point_cloud_args = {**point_cloud_args, "token": token}
-
     o = urlparse(uri)
 
     if not streaming:

--- a/pybabylonjs/args.py
+++ b/pybabylonjs/args.py
@@ -73,9 +73,20 @@ def check_point_cloud_args(source, mode, point_cloud_args_in):
             if key is not None:
                 point_cloud_args[key] = point_cloud_args_in.pop(key)
 
-    if not "height" in point_cloud_args:
-        point_cloud_args["height"] = 600
-        point_cloud_args["width"] = 800
+    def in_pixels(h, default):
+        if h is None:
+            return default
+        if isinstance(h, str):
+            if "px" in h:
+                return h
+            return h + "px"
+        if isinstance(h, int):
+            return str(h) + "px"
+        if isinstance(h, float):
+            return str(int(h)) + "px"
+
+    point_cloud_args["height"] = in_pixels(point_cloud_args.get("height"), "500px")
+    point_cloud_args["width"] = in_pixels(point_cloud_args.get("width"), "700px")
 
     if not "token" in point_cloud_args:
         try:

--- a/pybabylonjs/show.py
+++ b/pybabylonjs/show.py
@@ -60,7 +60,9 @@ class Show:
                 streaming, uri, point_cloud_args_in
             )
 
-        point_cloud_args = check_point_cloud_args(mode, point_cloud_args_in)
+        point_cloud_args = check_point_cloud_args(
+            source, streaming, point_cloud_args_in
+        )
 
         d = {
             **point_cloud_args,

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,10 +806,10 @@
     paralleljs "github:SarantopoulosKon/parallel.js#node-mode-in-web-worker"
     save-file "^2.3.1"
 
-"@tiledb-inc/viz-core@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@tiledb-inc/viz-core/-/viz-core-1.0.0.tgz#62bf814aeba300a2ad15b327d7b0b22aba3f9720"
-  integrity sha512-BPShN0I88R6O8Ca0VRK7ER0C/OkJwyEaRfgGYd6ElsdaGxRVM4t8ogQple1+073C3veRdrrAFzcmnkg3+3kGtA==
+"@tiledb-inc/viz-core@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tiledb-inc/viz-core/-/viz-core-1.0.1.tgz#5b00f4ec1f01ec498aef03e22fdaebc1842d61ee"
+  integrity sha512-Qrsv5LnGV2PvuL5nLojqfeZ7MAMgtl8QAK4OoTB1yWMhNXLdZbgGhSohRzHDmsWVkQNLffBDJCY7Qf8ml5x3mA==
   dependencies:
     "@babylonjs/core" "^5.42.0"
     "@babylonjs/gui" "^5.42.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,10 +806,10 @@
     paralleljs "github:SarantopoulosKon/parallel.js#node-mode-in-web-worker"
     save-file "^2.3.1"
 
-"@tiledb-inc/viz-core@^1.0.2-alpha.1":
-  version "1.0.2-alpha.1"
-  resolved "https://registry.yarnpkg.com/@tiledb-inc/viz-core/-/viz-core-1.0.2-alpha.1.tgz#db8310680c00f15962537f6e87616b1d82d8c962"
-  integrity sha512-O1OtzwWt3b/XBpvpJqrnxd1kE9eeusGauAw6DaWxnVMofFhJ6N6kajgVQ2rBr//3eNF5wdKmdD2UASDDJbw8Aw==
+"@tiledb-inc/viz-core@^1.0.2-alpha.2":
+  version "1.0.2-alpha.2"
+  resolved "https://registry.yarnpkg.com/@tiledb-inc/viz-core/-/viz-core-1.0.2-alpha.2.tgz#9f22b591f801cbe1e44a5cba85fbce40e69aea96"
+  integrity sha512-zC4IdCnuGi2UhuHZdPqY3WVbM9vQ8j4/fVzsqy6u+EnDJcV0vBcg1hVKw0k4tOxtcALbufKKnFR26LnGrAYLaA==
   dependencies:
     "@babylonjs/core" "^5.42.0"
     "@babylonjs/gui" "^5.42.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,10 +806,10 @@
     paralleljs "github:SarantopoulosKon/parallel.js#node-mode-in-web-worker"
     save-file "^2.3.1"
 
-"@tiledb-inc/viz-core@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@tiledb-inc/viz-core/-/viz-core-1.0.1.tgz#5b00f4ec1f01ec498aef03e22fdaebc1842d61ee"
-  integrity sha512-Qrsv5LnGV2PvuL5nLojqfeZ7MAMgtl8QAK4OoTB1yWMhNXLdZbgGhSohRzHDmsWVkQNLffBDJCY7Qf8ml5x3mA==
+"@tiledb-inc/viz-core@^1.0.2-alpha.1":
+  version "1.0.2-alpha.1"
+  resolved "https://registry.yarnpkg.com/@tiledb-inc/viz-core/-/viz-core-1.0.2-alpha.1.tgz#db8310680c00f15962537f6e87616b1d82d8c962"
+  integrity sha512-O1OtzwWt3b/XBpvpJqrnxd1kE9eeusGauAw6DaWxnVMofFhJ6N6kajgVQ2rBr//3eNF5wdKmdD2UASDDJbw8Aw==
   dependencies:
     "@babylonjs/core" "^5.42.0"
     "@babylonjs/gui" "^5.42.0"


### PR DESCRIPTION
A token was only loaded from the env when a cloud array was loaded, this caused issues with loading models together with a point cloud from a local array or dict. This PR files this, a token is always loaded from the env when available